### PR TITLE
feat(block_api): Added a Hello World block

### DIFF
--- a/tejas_block_api/README.md
+++ b/tejas_block_api/README.md
@@ -1,0 +1,39 @@
+# Tejas Block API Module
+
+This module provides a custom block named **"Hello World Block"** for Drupal 11.
+
+## Installation
+1. Place the module in `modules/custom/tejas_block_api`.
+2. Enable it via the command line:
+   ```sh
+   drush en tejas_block_api -y
+   drush cache:rebuild
+   ```
+
+## Usage
+### 1. Add via Admin UI
+- Go to **Structure → Block layout** (`/admin/structure/block`).
+- Click **"Place block"** in the desired region.
+- Search for **"Hello World Block"** and add it.
+
+### 2. Render in Twig
+```twig
+{{ drupal_block('tejas_hello_world_block') }}
+```
+
+### 3. Render Programmatically
+```php
+$block = \Drupal::service('plugin.manager.block')->createInstance('tejas_hello_world_block', []);
+$render = $block->build();
+```
+
+## File Structure
+```
+tejas_block_api/
+│── tejas_block_api.info.yml
+│── src/
+│   ├── Plugin/
+│   │   ├── Block/
+│   │   │   ├── HelloWorldBlock.php
+│── README.md
+```

--- a/tejas_block_api/src/Plugin/Block/HelloWorldBlock.php
+++ b/tejas_block_api/src/Plugin/Block/HelloWorldBlock.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\tejas_block_api\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Hello World' block.
+ *
+ * @Block(
+ *   id = "tejas_hello_world_block",
+ *   admin_label = @Translation("Hello World Block"),
+ * )
+ */
+class HelloWorldBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#markup' => $this->t('Hello, World!'),
+    ];
+  }
+
+}

--- a/tejas_block_api/tejas_block_api.info.yml
+++ b/tejas_block_api/tejas_block_api.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas Block API'
+type: module
+description: 'Provides a simple Hello World block.'
+core_version_requirement: ^11
+package: Custom


### PR DESCRIPTION
This PR introduces the **Tejas Block API** module, which provides a simple "Hello World" block for Drupal 11.  

#### Changes  
- Added `HelloWorldBlock.php` to `src/Plugin/Block/`, defining a custom block.  
- Created `tejas_block_api.info.yml` to register the module.  
- Added a `README.md` with installation and usage instructions.  

#### How to Test  
1. Enable the module:  
   ```sh
   drush en tejas_block_api -y  
   drush cache:rebuild  
   ```  
2. Add the block via **Structure → Block layout** or render it in Twig/programmatically.  

#### Notes  
- Compatible with Drupal 11.  
- Uses `@Block` annotation to register the block.