### PR TITLE
feat(services & dependency injection): Created an events fetching service on /service-event route

### DIFF
--- a/tejas_block_api/README.md
+++ b/tejas_block_api/README.md
@@ -1,0 +1,39 @@
+# Tejas Block API Module
+
+This module provides a custom block named **"Hello World Block"** for Drupal 11.
+
+## Installation
+1. Place the module in `modules/custom/tejas_block_api`.
+2. Enable it via the command line:
+   ```sh
+   drush en tejas_block_api -y
+   drush cache:rebuild
+   ```
+
+## Usage
+### 1. Add via Admin UI
+- Go to **Structure → Block layout** (`/admin/structure/block`).
+- Click **"Place block"** in the desired region.
+- Search for **"Hello World Block"** and add it.
+
+### 2. Render in Twig
+```twig
+{{ drupal_block('tejas_hello_world_block') }}
+```
+
+### 3. Render Programmatically
+```php
+$block = \Drupal::service('plugin.manager.block')->createInstance('tejas_hello_world_block', []);
+$render = $block->build();
+```
+
+## File Structure
+```
+tejas_block_api/
+│── tejas_block_api.info.yml
+│── src/
+│   ├── Plugin/
+│   │   ├── Block/
+│   │   │   ├── HelloWorldBlock.php
+│── README.md
+```

--- a/tejas_block_api/src/Plugin/Block/HelloWorldBlock.php
+++ b/tejas_block_api/src/Plugin/Block/HelloWorldBlock.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\tejas_block_api\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Hello World' block.
+ *
+ * @Block(
+ *   id = "tejas_hello_world_block",
+ *   admin_label = @Translation("Hello World Block"),
+ * )
+ */
+class HelloWorldBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#markup' => $this->t('Hello, World!'),
+    ];
+  }
+
+}

--- a/tejas_block_api/tejas_block_api.info.yml
+++ b/tejas_block_api/tejas_block_api.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas Block API'
+type: module
+description: 'Provides a simple Hello World block.'
+core_version_requirement: ^11
+package: Custom

--- a/tejas_routes_controllers/README.md
+++ b/tejas_routes_controllers/README.md
@@ -1,0 +1,27 @@
+# Tejas Routes & Controllers Module
+
+This module provides a custom route (`/events/more-events`) that fetches events from a mock API and renders them using a Twig template.
+
+## Installation
+1. Place the module in `modules/custom/tejas_routes_controllers`.
+2. Enable it via the command line:
+   ```sh
+   drush en tejas_routes_controllers -y
+   drush cache:rebuild
+   ```
+
+## Usage
+- Visit `/events/more-events` to see a list of upcoming events fetched from a mock API.
+
+## Folder Structure
+```
+tejas_routes_controllers/
+│── tejas_routes_controllers.info.yml
+│── tejas_routes_controllers.routing.yml
+│── src/
+│   ├── Controller/
+│   │   ├── EventController.php
+│── templates/
+│   ├── more-events-template.html.twig
+│── README.md
+```

--- a/tejas_routes_controllers/README.md
+++ b/tejas_routes_controllers/README.md
@@ -1,19 +1,29 @@
+
 # Tejas Routes & Controllers Module
 
-This module provides a custom route (`/events/more-events`) that fetches events from a mock API and renders them using a Twig template.
+This module provides a custom route (`/more-events`) that returns a hardcoded HTML response with a list of upcoming events.
 
 ## Installation
+
 1. Place the module in `modules/custom/tejas_routes_controllers`.
-2. Enable it via the command line:
+2. Enable the module using Drush:
    ```sh
    drush en tejas_routes_controllers -y
    drush cache:rebuild
    ```
 
 ## Usage
-- Visit `/events/more-events` to see a list of upcoming events fetched from a mock API.
+
+- Visit **`/more-events`** to see the hardcoded list of events.
+
+## Route Information
+
+| Path                 | Controller Method                          | Permission       |
+|----------------------|------------------------------------------|-----------------|
+| `/events/more-events` | `EventController::build()` | `access content` |
 
 ## Folder Structure
+
 ```
 tejas_routes_controllers/
 │── tejas_routes_controllers.info.yml
@@ -21,7 +31,25 @@ tejas_routes_controllers/
 │── src/
 │   ├── Controller/
 │   │   ├── EventController.php
-│── templates/
-│   ├── more-events-template.html.twig
 │── README.md
+```
+
+## Example Output
+
+When you visit `/more-events`, you will see:
+
+```
+Upcoming Events
+
+Drupal Meetup
+Date: April 10, 2025
+Join us for an exciting discussion on the latest Drupal features.
+
+React Conference
+Date: May 5, 2025
+Explore the future of React.js with industry experts.
+
+Open Source Summit
+Date: June 15, 2025
+A deep dive into open-source contributions and collaborations.
 ```

--- a/tejas_routes_controllers/src/Controller/EventController.php
+++ b/tejas_routes_controllers/src/Controller/EventController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\tejas_routes_controllers\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Controller for handling event-related routes.
+ */
+class EventController extends ControllerBase {
+
+  /**
+   * Returns a hardcoded HTML response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The HTML response.
+   */
+  public function build() {
+    $html = '
+      <h1>Upcoming Events</h1>
+      <div class="events-list">
+        <div class="event">
+          <h2>Drupal Meetup</h2>
+          <p><strong>Date:</strong> April 10, 2025</p>
+          <p>Join us for an exciting discussion on the latest Drupal features.</p>
+        </div>
+        <div class="event">
+          <h2>React Conference</h2>
+          <p><strong>Date:</strong> May 5, 2025</p>
+          <p>Explore the future of React.js with industry experts.</p>
+        </div>
+        <div class="event">
+          <h2>Open Source Summit</h2>
+          <p><strong>Date:</strong> June 15, 2025</p>
+          <p>A deep dive into open-source contributions and collaborations.</p>
+        </div>
+      </div>
+    ';
+
+    return new Response($html);
+  }
+
+}

--- a/tejas_routes_controllers/tejas_routes_controllers.info.yml
+++ b/tejas_routes_controllers/tejas_routes_controllers.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas Routes & Controllers'
+type: module
+description: 'Provides custom routes and controllers for the Events website with API integration.'
+core_version_requirement: ^11
+package: Custom

--- a/tejas_routes_controllers/tejas_routes_controllers.routing.yml
+++ b/tejas_routes_controllers/tejas_routes_controllers.routing.yml
@@ -1,0 +1,7 @@
+tejas_routes_controllers.more_events:
+  path: '/more-events'
+  defaults:
+    _controller: '\Drupal\tejas_routes_controllers\Controller\EventController::build'
+    _title: 'More Events'
+  requirements:
+    _permission: 'access content'

--- a/tejas_services_dependency_injection/README.md
+++ b/tejas_services_dependency_injection/README.md
@@ -1,0 +1,91 @@
+
+# Tejas Services & Dependency Injection Module
+
+This module demonstrates how to create and use a **custom service** in Drupal 11 with **proper dependency injection**.
+
+## Features
+
+-   Registers `EventService` to fetch event data from an external API.
+-   Injects the service into `EventController` for structured API calls.
+-   Provides a route `/service-events` that directly **renders HTML output** inside the controller.
+
+## Installation
+
+1.  Place the module in:
+    
+    ```
+    modules/custom/tejas_services_dependency_injection/
+    
+    ```
+    
+2.  Enable the module using Drush:
+    
+    ```sh
+    drush en tejas_services_dependency_injection -y
+    drush cache:rebuild
+    
+    ```
+    
+3.  Visit `/service-events` in your browser to see the events.
+
+## Folder Structure
+
+```
+tejas_services_dependency_injection/
+│── tejas_services_dependency_injection.info.yml
+│── tejas_services_dependency_injection.services.yml
+│── src/
+│   ├── Service/
+│   │   ├── EventService.php
+│   ├── Controller/
+│   │   ├── EventController.php
+│── tejas_services_dependency_injection.routing.yml
+│── README.md
+
+```
+
+## How It Works
+
+1.  **Service (`EventService`)**
+    
+    -   Fetches event data from an external API using Guzzle.
+    -   Registered in `tejas_services_dependency_injection.services.yml`.
+2.  **Controller (`EventController`)**
+    
+    -   Injects `EventService` via **dependency injection**.
+    -   Calls `build()` method to retrieve event data.
+    -   **Directly returns HTML output** instead of using templates.
+3.  **Route (`/service-events`)**
+    
+    -   Calls `EventController::build()`, which fetches event data and displays it.
+
+## Example Output
+
+When you visit `/service-events`, you will see:
+
+```
+Event Listings
+
+Drupal Meetup
+Date: April 10, 2025
+A meetup discussing the latest in Drupal.
+
+React Conference
+Date: May 5, 2025
+A deep dive into React's future.
+
+Open Source Summit
+Date: June 15, 2025
+A conference on open-source contributions.
+
+```
+
+## Notes
+
+-   Compatible with **Drupal 11**.
+-   Uses **Symfony’s dependency injection** for better code separation.
+-   No use of Twig or Drupal’s render API—HTML is **generated inside the controller**.
+
+----------
+
+**Now, visit** `/service-events` **and see your service in action!**

--- a/tejas_services_dependency_injection/src/Controller/EventController.php
+++ b/tejas_services_dependency_injection/src/Controller/EventController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\tejas_services_dependency_injection\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\tejas_services_dependency_injection\Service\EventService;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Controller to display events fetched via the EventService.
+ */
+class EventController extends ControllerBase {
+
+  /**
+   * The event service.
+   *
+   * @var \Drupal\tejas_services_dependency_injection\Service\EventService
+   */
+  protected EventService $eventService;
+
+  /**
+   * Constructs the EventController.
+   *
+   * @param \Drupal\tejas_services_dependency_injection\Service\EventService $event_service
+   *   The event service.
+   */
+  public function __construct(EventService $event_service) {
+    $this->eventService = $event_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('tejas_services_dependency_injection.event_service')
+    );
+  }
+
+  /**
+   * Displays the list of events directly as an HTML response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   A response containing HTML content.
+   */
+  public function build(): Response {
+    $events = $this->eventService->getEvents();
+    $html = "<h1>Event Listings</h1><div class='events-container'>";
+
+    foreach ($events as $event) {
+      $html .= "<div class='event-card'>";
+      $html .= "<h2>{$event['name']}</h2>";
+      $html .= "<p><strong>Date:</strong> {$event['datetime']}</p>";
+      $html .= "<p>{$event['description']}</p>";
+      $html .= "</div>";
+    }
+
+    $html .= "</div>";
+
+    return new Response($html);
+  }
+
+}

--- a/tejas_services_dependency_injection/src/Service/EventService.php
+++ b/tejas_services_dependency_injection/src/Service/EventService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\tejas_services_dependency_injection\Service;
+
+use GuzzleHttp\ClientInterface;
+use Drupal\Component\Serialization\Json;
+
+/**
+ * Service to fetch event data from an external API.
+ */
+class EventService {
+
+  /**
+   * The HTTP client for making requests.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * Constructs the EventService.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   */
+  public function __construct(ClientInterface $http_client) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * Fetches events from an external API.
+   *
+   * @return array
+   *   The decoded JSON response.
+   */
+  public function getEvents(): array {
+    try {
+      $response = $this->httpClient->request('GET', 'https://67d7ea5b9d5e3a10152c8af1.mockapi.io/event');
+      return Json::decode($response->getBody()->getContents());
+    }
+    catch (\Exception $e) {
+      return ['error' => $e->getMessage()];
+    }
+  }
+
+}

--- a/tejas_services_dependency_injection/tejas_services_dependency_injection.info.yml
+++ b/tejas_services_dependency_injection/tejas_services_dependency_injection.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas Services & Dependency Injection'
+type: module
+description: 'Demonstrates service creation and dependency injection in a Drupal 11 module.'
+core_version_requirement: ^11
+package: Custom

--- a/tejas_services_dependency_injection/tejas_services_dependency_injection.routing.yml
+++ b/tejas_services_dependency_injection/tejas_services_dependency_injection.routing.yml
@@ -1,0 +1,7 @@
+tejas_services_dependency_injection.service_events:
+  path: '/service-events'
+  defaults:
+    _controller: 'Drupal\tejas_services_dependency_injection\Controller\EventController::build'
+    _title: 'Service Events'
+  requirements:
+    _permission: 'access content'

--- a/tejas_services_dependency_injection/tejas_services_dependency_injection.services.yml
+++ b/tejas_services_dependency_injection/tejas_services_dependency_injection.services.yml
@@ -1,0 +1,4 @@
+services:
+  tejas_services_dependency_injection.event_service:
+    class: 'Drupal\tejas_services_dependency_injection\Service\EventService'
+    arguments: ['@http_client']

--- a/tejas_services_dependency_injection/templates/event-list.html.twig
+++ b/tejas_services_dependency_injection/templates/event-list.html.twig
@@ -1,0 +1,16 @@
+{% extends 'page.html.twig' %}
+
+{% block content %}
+  <h1>Event Listings</h1>
+  <div class="events-container">
+    {% for event in events %}
+      <div class="event-card">
+        <h2>{{ event.title }}</h2>
+        <p><strong>Date:</strong> {{ event.date }}</p>
+        <p>{{ event.description }}</p>
+      </div>
+    {% else %}
+      <p>No events found.</p>
+    {% endfor %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
This PR introduces the **Tejas Services & Dependency Injection** module, which demonstrates how to create and utilize a custom service in Drupal 11 using proper **dependency injection**.  

#### **Changes**  
✅ Added `EventService.php` in `src/Service/` to fetch event data.  
✅ Created `EventController.php` in `src/Controller/` to inject the service and display event data.  
✅ Registered the service in `tejas_services_dependency_injection.services.yml`.  
✅ Defined a route `/service-events` in `tejas_services_dependency_injection.routing.yml`.  
✅ Added `README.md` with installation steps, usage, and folder structure.  

#### **How to Test**  
1. Enable the module:  
   ```sh
   drush en tejas_services_dependency_injection -y  
   drush cache:rebuild  
   ```  
2. Visit `/service-events` to see hardcoded event data displayed directly from the controller.  

#### **Notes**  
- Uses **Symfony’s dependency injection** for better structure.  
- Does **not** use Twig templates or the Render API—**HTML is directly returned from the controller**.  
- Compatible with **Drupal 11**.  