### PR TITLE
feat(state_api): Used state api to call events api after 10 minutes of lasttime sync at /state-events route

### DIFF
--- a/tejas_state_api/README.md
+++ b/tejas_state_api/README.md
@@ -1,0 +1,33 @@
+# Tejas State API Module
+
+This module leverages Drupal's State API to cache event data and reduce frequent external API calls, optimizing performance for the Events website.
+
+## Installation
+1. Place the module in `modules/custom/tejas_state_api`.
+2. Enable the module:
+   ```sh
+   drush en tejas_state_api -y
+   drush cache:rebuild
+   ```
+
+## Usage
+- Visit **`/state-events`** to see events fetched using the State API.
+- The API is queried only once every 10 minutes, reducing unnecessary requests.
+
+## Folder Structure
+```
+tejas_state_api/
+│── tejas_state_api.info.yml
+│── tejas_state_api.services.yml
+│── tejas_state_api.routing.yml
+│── src/
+│   ├── Controller/
+│   │   ├── EventStateController.php
+│   ├── Service/
+│   │   ├── EventStateService.php
+│   ├── Hook/
+│   │   ├── ThemeHook.php
+│── templates/
+│   ├── event-state-card.html.twig
+│── README.md
+```

--- a/tejas_state_api/src/Controller/EventStateController.php
+++ b/tejas_state_api/src/Controller/EventStateController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\tejas_state_api\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\tejas_state_api\Service\EventStateService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for rendering events using State API.
+ */
+class EventStateController extends ControllerBase {
+
+  /**
+   * The event state service.
+   *
+   * @var \Drupal\tejas_state_api\Service\EventStateService
+   */
+  protected $eventStateService;
+
+  /**
+   * Constructs an EventStateController object.
+   */
+  public function __construct(EventStateService $eventStateService) {
+    $this->eventStateService = $eventStateService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('tejas_state_api.event_state_service')
+    );
+  }
+
+  /**
+   * Builds a render array for events.
+   */
+  public function build() {
+    $events = $this->eventStateService->getOptimizedEvents();
+    $renderedEvents = [];
+
+    foreach ($events as $event) {
+      $renderedEvents[] = [
+        '#theme' => 'event_state_card',
+        '#name' => $event['name'],
+        '#datetime' => $event['datetime'],
+        '#description' => $event['description'],
+      ];
+    }
+
+    return [
+      '#markup' => '<h1>State API Optimized Events</h1>',
+      'events' => $renderedEvents,
+    ];
+  }
+
+}

--- a/tejas_state_api/src/Hook/ThemeHook.php
+++ b/tejas_state_api/src/Hook/ThemeHook.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\tejas_state_api\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Hooks related to theming and content output.
+ */
+class ThemeHook {
+
+  /**
+   * Implements hook_theme().
+   */
+  #[Hook('theme')]
+  public function theme(): array {
+    return [
+      'event_state_card' => [
+        'variables' => [
+          'name' => '',
+          'datetime' => '',
+          'description' => '',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/tejas_state_api/src/Service/EventStateService.php
+++ b/tejas_state_api/src/Service/EventStateService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\tejas_state_api\Service;
+
+use Drupal\Core\State\StateInterface;
+use GuzzleHttp\ClientInterface;
+use Drupal\Component\Serialization\Json;
+
+/**
+ * Service to fetch event data with State API optimization.
+ */
+class EventStateService {
+
+  /**
+   * The HTTP client for making requests.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * The State API service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected StateInterface $state;
+
+  /**
+   * Constructs the EventStateService.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The State API service.
+   */
+  public function __construct(ClientInterface $http_client, StateInterface $state) {
+    $this->httpClient = $http_client;
+    $this->state = $state;
+  }
+
+  /**
+   * Fetches events from an external API only if needed.
+   *
+   * @return array
+   *   The decoded JSON response.
+   */
+  public function getOptimizedEvents(): array {
+    $lastFetched = $this->state->get('tejas_state_api.last_fetched', 0);
+    $currentTime = time();
+    $cacheDuration = 600;
+
+    if ($currentTime - $lastFetched < $cacheDuration) {
+      return $this->state->get('tejas_state_api.cached_events', []);
+    }
+
+    try {
+      $response = $this->httpClient->request('GET', 'https://67d7ea5b9d5e3a10152c8af1.mockapi.io/event');
+      $events = Json::decode($response->getBody()->getContents());
+      $this->state->set('tejas_state_api.cached_events', $events);
+      $this->state->set('tejas_state_api.last_fetched', $currentTime);
+      return $events;
+    }
+    catch (\Exception $e) {
+      return ['error' => $e->getMessage()];
+    }
+  }
+
+}

--- a/tejas_state_api/tejas_state_api.info.yml
+++ b/tejas_state_api/tejas_state_api.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas State API'
+type: module
+description: 'Utilizes the State API to cache event data and reduce external API calls.'
+core_version_requirement: ^11
+package: Custom

--- a/tejas_state_api/tejas_state_api.routing.yml
+++ b/tejas_state_api/tejas_state_api.routing.yml
@@ -1,0 +1,7 @@
+tejas_state_api.render_state_events:
+  path: '/state-events'
+  defaults:
+    _controller: 'Drupal\tejas_state_api\Controller\EventStateController::build'
+    _title: 'State API Events'
+  requirements:
+    _permission: 'access content'

--- a/tejas_state_api/tejas_state_api.services.yml
+++ b/tejas_state_api/tejas_state_api.services.yml
@@ -1,0 +1,4 @@
+services:
+  tejas_state_api.event_state_service:
+    class: 'Drupal\tejas_state_api\Service\EventStateService'
+    arguments: ['@http_client', '@state']

--- a/tejas_state_api/templates/event-state-card.html.twig
+++ b/tejas_state_api/templates/event-state-card.html.twig
@@ -1,0 +1,5 @@
+<div class="event-card">
+  <h2>{{ name }}</h2>
+  <p><strong>Date:</strong> {{ datetime }}</p>
+  <p>{{ description }}</p>
+</div>


### PR DESCRIPTION
This PR introduces the `Tejas State API` module, which optimizes external API requests for event data by leveraging Drupal's **State API**. Instead of making frequent API calls, it caches event data in the State API and only fetches new data if the last request was made more than **10 minutes ago**.  

### **Changes:**  
- Added `EventStateService.php` in `src/Service/`, which uses the **State API** to store and retrieve cached event data.  
- Created `EventStateController.php` in `src/Controller/` to expose the event data at `/state-events`.  
- Added `tejas_state_api.routing.yml` to register the route.  
- Defined `tejas_state_api.info.yml` to declare the module.  
- Included `README.md` with installation and usage instructions.  
- Created `event-state-card.html.twig` to display events in a structured format.  

### **How to Test:**  
1. Enable the module:  
   ```sh
   drush en tejas_state_api -y  
   drush cache:rebuild  
   ```  
2. Visit `/state-events` in the browser to see event listings.  
3. The first request fetches fresh event data from the external API.  
4. Subsequent requests within **10 minutes** serve cached data from the **State API**.  
5. After 10 minutes, the module fetches fresh data and updates the cache.  

### **Notes:**  
- Compatible with **Drupal 11**.  
- Reduces external API calls by **caching responses in the State API**.  
- Uses a **class-based service approach** for clean architecture.  