### PR TITLE
feat(cache_api): Utilised caching in build array and in api service

### DIFF
--- a/tejas_cache_api/README.md
+++ b/tejas_cache_api/README.md
@@ -1,0 +1,107 @@
+# Tejas Cache API Module
+
+This module provides a custom route (`/cache-events`) that dynamically fetches event data from an external API and caches the results using Drupal's caching system.
+
+## Installation
+
+1. Place the module in `modules/custom/tejas_cache_api`.
+2. Enable the module using Drush:
+   ```sh
+   drush en tejas_cache_api -y
+   drush cache:rebuild
+   ```
+
+## Usage
+
+- Visit **`/cache-events`** to see the list of cached events retrieved from an external API.
+
+## Route Information
+
+| Path           | Controller Method            | Permission       |
+|---------------|----------------------------|-----------------|
+| `/cache-events` | `EventController::build()` | `access content` |
+
+## Folder Structure
+
+```
+tejas_cache_api/
+│── tejas_cache_api.info.yml
+│── tejas_cache_api.routing.yml
+│── tejas_cache_api.services.yml
+│── src/
+│   ├── Controller/
+│   │   ├── EventController.php
+│   ├── Service/
+│   │   ├── EventService.php
+│   ├── Hook/
+│   │   ├── ThemeHook.php
+│── templates/
+│   ├── event-card.html.twig
+│── README.md
+```
+
+## Example Output
+
+When you visit `/cache-events`, you will see:
+
+```
+Cached Events
+
+Event Name: Drupal Meetup
+Date: April 10, 2025
+Description: Join us for an exciting discussion on the latest Drupal features.
+
+Event Name: React Conference
+Date: May 5, 2025
+Description: Explore the future of React.js with industry experts.
+
+Event Name: Open Source Summit
+Date: June 15, 2025
+Description: A deep dive into open-source contributions and collaborations.
+```
+
+## Services
+
+### `tejas_cache_api.event_service`
+- Fetches event data from an external API (`https://67d7ea5b9d5e3a10152c8af1.mockapi.io/event`).
+- Uses `GuzzleHttp\ClientInterface` to make requests.
+- Implements caching using `Drupal\Core\Cache\CacheBackendInterface`.
+
+## Caching Mechanism
+
+This module implements caching at two levels:
+
+1. **ID-based Caching**:
+   - Stores event data in Drupal's cache system using a cache ID (`tejas_cache_api:events`).
+   - Data is retrieved from cache before making an API request.
+   - Uses `CACHE_PERMANENT` to store data persistently.
+
+2. **Render Array Caching**:
+   - The rendered event list includes cache metadata:
+   ```php
+   '#cache' => [
+      'contexts' => ['url'],
+   ],
+   ```
+   - Ensures that content is cached separately for each URL variation.
+
+## Theming
+
+The `event-card.html.twig` template renders individual event cards:
+
+```twig
+<div class="event-card">
+  <h2>{{ name }}</h2>
+  <p><strong>Date:</strong> {{ datetime }}</p>
+  <p>{{ description }}</p>
+</div>
+```
+
+## Extending the Module
+
+- Modify `EventService.php` to add more caching strategies.
+- Update `EventController.php` to handle cache invalidation where necessary.
+- Use `'#cache' => ['tags' => ['custom_tag']]` if cache invalidation needs to be tied to configuration changes.
+
+This module demonstrates a structured approach to caching in Drupal, optimizing performance while ensuring dynamic content updates.
+

--- a/tejas_cache_api/src/Controller/EventController.php
+++ b/tejas_cache_api/src/Controller/EventController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\tejas_cache_api\Controller;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\tejas_cache_api\Service\EventService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Controller for rendering cached events.
+ */
+class EventController extends ControllerBase {
+
+  /**
+   * The event service.
+   *
+   * @var \Drupal\tejas_cache_api\Service\EventService
+   */
+  protected EventService $eventService;
+
+  /**
+   * Constructs an EventController object.
+   *
+   * @param \Drupal\tejas_cache_api\Service\EventService $eventService
+   *   The event service.
+   */
+  public function __construct(EventService $eventService) {
+    $this->eventService = $eventService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('tejas_cache_api.event_service')
+    );
+  }
+
+  /**
+   * Builds a render array for cached events with cacheability metadata.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function build() {
+    $events = $this->eventService->getEvents();
+    $renderedEvents = [];
+
+    foreach ($events as $event) {
+      $renderedEvents[] = [
+        '#theme' => 'event_card',
+        '#name' => $event['name'],
+        '#datetime' => $event['datetime'],
+        '#description' => $event['description'],
+      ];
+    }
+
+    $render_array = [
+      '#markup' => '<h1>Cached Events</h1>',
+      'events' => $renderedEvents,
+      '#cache' => [
+        'contexts' => ['url'],
+      ],
+    ];
+
+    return $render_array;
+  }
+
+}

--- a/tejas_cache_api/src/Hook/ThemeHook.php
+++ b/tejas_cache_api/src/Hook/ThemeHook.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\tejas_cache_api\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Hooks related to theming and content output.
+ */
+class ThemeHook {
+
+  /**
+   * Implements hook_theme().
+   *
+   * @return array
+   *   The theme hook definitions.
+   */
+  #[Hook('theme')]
+  public function theme(): array {
+    return [
+      'event_card' => [
+        'variables' => [
+          'name' => '',
+          'datetime' => '',
+          'description' => '',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/tejas_cache_api/src/Service/EventService.php
+++ b/tejas_cache_api/src/Service/EventService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\tejas_cache_api\Service;
+
+use GuzzleHttp\ClientInterface;
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Cache\CacheBackendInterface;
+
+/**
+ * Service to fetch and cache event data from an external API.
+ */
+class EventService {
+
+  /**
+   * The HTTP client for making requests.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * The cache backend interface.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected CacheBackendInterface $cache;
+
+  /**
+   * Constructs the EventService.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
+   *   The cache backend service.
+   */
+  public function __construct(ClientInterface $http_client, CacheBackendInterface $cache) {
+    $this->httpClient = $http_client;
+    $this->cache = $cache;
+  }
+
+  /**
+   * Fetches events from an external API with caching.
+   *
+   * @return array
+   *   The decoded JSON response.
+   */
+  public function getEvents(): array {
+    $cache_id = 'tejas_cache_api:events';
+    if ($cache = $this->cache->get($cache_id)) {
+      return $cache->data;
+    }
+
+    try {
+      $response = $this->httpClient->request('GET', 'https://67d7ea5b9d5e3a10152c8af1.mockapi.io/event');
+      $data = Json::decode($response->getBody()->getContents());
+      $this->cache->set($cache_id, $data);
+      return $data;
+    }
+    catch (\Exception $e) {
+      return ['error' => $e->getMessage()];
+    }
+  }
+
+}

--- a/tejas_cache_api/tejas_cache_api.info.yml
+++ b/tejas_cache_api/tejas_cache_api.info.yml
@@ -1,0 +1,5 @@
+name: 'Tejas Cache API'
+type: module
+description: 'Provides a caching-based implementation for displaying events.'
+core_version_requirement: ^11
+package: Custom

--- a/tejas_cache_api/tejas_cache_api.routing.yml
+++ b/tejas_cache_api/tejas_cache_api.routing.yml
@@ -1,0 +1,7 @@
+tejas_cache_api.render_events:
+  path: '/cache-events'
+  defaults:
+    _controller: 'Drupal\tejas_cache_api\Controller\EventController::build'
+    _title: 'Cached Events'
+  requirements:
+    _permission: 'access content'

--- a/tejas_cache_api/tejas_cache_api.services.yml
+++ b/tejas_cache_api/tejas_cache_api.services.yml
@@ -1,0 +1,4 @@
+services:
+  tejas_cache_api.event_service:
+    class: 'Drupal\tejas_cache_api\Service\EventService'
+    arguments: ['@http_client', '@cache.default']


### PR DESCRIPTION
This PR introduces the **Tejas Cache API** module, which fetches event data from an external API and caches it using Drupal’s caching system. The module provides a custom route (`/cache-events`) that renders cached events using a theme template.

## Key Features
- **Event Fetching**: Uses `GuzzleHttp\ClientInterface` to fetch events from an external API.
- **Caching Implementation**: Implements `Drupal\Core\Cache\CacheBackendInterface` to store API responses.
- **Custom Theme Hook**: Uses `event_card` theme hook for rendering.
- **Controller-Based Rendering**: Provides `EventController::build()` to display cached events.

## Testing Instructions
1. Enable the module:
   ```sh
   drush en tejas_cache_api -y
   drush cache:rebuild
   ```
2. Visit `/cache-events` to verify event rendering.