### PR TITLE
feat(vaibhav_field_api): Created a custom field to pick a date

### DIFF
--- a/vaibhav_field_api/config/schema/vaibhav_field_api.schema.yml
+++ b/vaibhav_field_api/config/schema/vaibhav_field_api.schema.yml
@@ -1,0 +1,7 @@
+field.field_settings.calendar_field:
+  type: mapping
+  label: 'Calendar field settings'
+  mapping:
+    value:
+      type: string
+      label: 'Date value'

--- a/vaibhav_field_api/readme.md
+++ b/vaibhav_field_api/readme.md
@@ -1,0 +1,14 @@
+
+# Vaibhav Field API
+
+## Description
+Provides a custom field type for Drupal that displays a calendar picker. It stores the selected date in a varchar column.
+
+## Installation
+1. Copy this module folder to your “modules/custom” directory.
+2. Enable the module in the “Extend” section of Drupal’s admin.
+
+## Usage
+1. Create or edit a content type.
+2. Add a field of type “Calendar Picker” which is available under **Custom** category.
+3. Use your content type as usual and select a date from the calendar.

--- a/vaibhav_field_api/src/Plugin/Field/FieldFormatter/CalendarFormatter.php
+++ b/vaibhav_field_api/src/Plugin/Field/FieldFormatter/CalendarFormatter.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\vaibhav_field_api\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'calendar_formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "calendar_formatter",
+ *   label = @Translation("Calendar Formatter"),
+ *   field_types = {"calendar_field"}
+ * )
+ */
+class CalendarFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * Constructs a CalendarFormatter object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter service.
+   */
+  public function __construct($plugin_id, $plugin_definition, $field_definition, array $settings, $label, $view_mode, array $third_party_settings, DateFormatterInterface $date_formatter) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      if (!empty($item->value)) {
+        $date = DrupalDateTime::createFromFormat('Y-m-d', $item->value);
+        $elements[$delta] = [
+          '#markup' => $this->dateFormatter->format($date->getTimestamp(), 'custom', 'F j, Y'),
+        ];
+      }
+    }
+
+    return $elements;
+  }
+
+}

--- a/vaibhav_field_api/src/Plugin/Field/FieldType/CalendarItem.php
+++ b/vaibhav_field_api/src/Plugin/Field/FieldType/CalendarItem.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\vaibhav_field_api\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines a 'calendar_field' field type.
+ *
+ * @FieldType(
+ *   id = "calendar_field",
+ *   label = @Translation("Calendar Picker"),
+ *   description = @Translation("Stores a date value with calendar picker."),
+ *   category = "custom",
+ *   default_widget = "calendar_widget",
+ *   default_formatter = "calendar_formatter"
+ * )
+ */
+class CalendarItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [
+      'columns' => [
+        'value' => [
+          'type' => 'varchar',
+          'length' => 20,
+          'not null' => FALSE,
+        ],
+      ],
+      'indexes' => [
+        'value' => ['value'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties['value'] = DataDefinition::create('string')
+      ->setLabel(t('Date value'))
+      ->setRequired(TRUE);
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $value = $this->get('value')->getValue();
+    return $value === NULL || $value === '';
+  }
+
+}

--- a/vaibhav_field_api/src/Plugin/Field/FieldWidget/CalendarWidget.php
+++ b/vaibhav_field_api/src/Plugin/Field/FieldWidget/CalendarWidget.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\vaibhav_field_api\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'calendar_widget' widget.
+ *
+ * @FieldWidget(
+ *   id = "calendar_widget",
+ *   label = @Translation("Calendar Picker"),
+ *   field_types = {"calendar_field"}
+ * )
+ */
+class CalendarWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element['value'] = $element + [
+      '#type' => 'date',
+      '#default_value' => $items[$delta]->value ?? '',
+      '#description' => $this->t('Select a date'),
+      '#attributes' => [
+        'class' => ['custom-calendar-picker'],
+      ],
+    ];
+
+    return $element;
+  }
+
+}

--- a/vaibhav_field_api/vaibhav_field_api.field_type_categories.yml
+++ b/vaibhav_field_api/vaibhav_field_api.field_type_categories.yml
@@ -1,0 +1,4 @@
+custom:
+  label: 'Custom Fields'
+  description: 'Custom field types defined by the Vaibhav Field API module.'
+  weight: 10

--- a/vaibhav_field_api/vaibhav_field_api.info.yml
+++ b/vaibhav_field_api/vaibhav_field_api.info.yml
@@ -1,0 +1,7 @@
+name: Calendar Field
+type: module
+description: 'Provides a calendar picker field type.'
+package: Vaibhav
+core_version_requirement: ^11
+dependencies:
+  - drupal:datetime

--- a/vaibhav_field_api/vaibhav_field_api.module
+++ b/vaibhav_field_api/vaibhav_field_api.module
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Contains hook implementations for the Custom Calendar Field module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function vaibhav_field_api_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.vaibhav_field_api':
+      return '<p>' . t('Provides a calendar picker field type for date selection.') . '</p>';
+  }
+}


### PR DESCRIPTION
Provides a custom field type for Drupal that displays a calendar picker. It stores the selected date in a varchar column.

## Installation
1. Copy this module folder to your “modules/custom” directory.
2. Enable the module in the “Extend” section of Drupal’s admin.

## Usage
1. Create or edit a content type.
2. Add a field of type “Calendar Picker” which is available under **Custom** category.
3. Use your content type as usual and select a date from the calendar.
