### PR TITLE
feat(state_api): Add State API module for custom state management at /admin/states

### DIFF
--- a/vaibhav_state_api/config/schema/vaibhav_state_api.schema.yml
+++ b/vaibhav_state_api/config/schema/vaibhav_state_api.schema.yml
@@ -1,0 +1,10 @@
+vaibhav_state_api.manager:
+  type: config_object
+  label: 'Vaibhav State API configuration'
+  mapping:
+    storage:
+      type: sequence
+      label: 'State storage'
+      sequence:
+        type: string
+        label: 'State entry'

--- a/vaibhav_state_api/css/vaibhav-state-api.css
+++ b/vaibhav_state_api/css/vaibhav-state-api.css
@@ -1,0 +1,21 @@
+.vaibhav-state-demo {
+    background: #f0f0f0;
+    padding: 20px;
+    border-radius: 5px;
+    margin: 20px 0;
+}
+
+.value-at-page-load {
+  color: blue;
+  font-weight: bold;
+}
+
+.action-performed {
+  color: green;
+  font-weight: bold;
+}
+
+.value-after-action {
+  color: red;
+  font-weight: bold;
+}

--- a/vaibhav_state_api/js/vaibhav_state_api.js
+++ b/vaibhav_state_api/js/vaibhav_state_api.js
@@ -1,0 +1,20 @@
+(function ($, Drupal) {
+  Drupal.behaviors.vaibhavStateApi = {
+    attach: function (context, settings) {
+      $('.use-ajax', context).once('vaibhavStateApi').on('click', function (e) {
+        e.preventDefault();
+        var $link = $(this);
+        $.ajax({
+          url: $link.attr('href'),
+          type: 'GET',
+          dataType: 'json',
+          success: function (data) {
+            $('p.value-at-page-load').text('Value at page load: ' + data.current_value);
+            $('p.action-performed').text('Action performed: ' + data.after_action);
+            $('p.value-after-action').text('Value after action: ' + data.final_value);
+          }
+        });
+      });
+    }
+  };
+})(jQuery, Drupal);

--- a/vaibhav_state_api/readme.md
+++ b/vaibhav_state_api/readme.md
@@ -1,0 +1,38 @@
+# Vaibhav State API
+
+## Overview
+
+The Vaibhav State API module provides a demonstration of using the Drupal State API to store and manage persistent state information. This module includes a custom state plugin and a controller to showcase the functionality.
+
+## Features
+
+- Custom state plugin: `CustomState`
+- Demo page to interact with the State API
+
+## Installation
+
+1. Download and place the `vaibhav_state_api` module in your Drupal site's `modules/custom` directory.
+2. Enable the module using the following Drush command:
+   ```sh
+   drush en vaibhav_state_api
+   ```
+   Or enable it through the Drupal admin interface.
+
+## Usage
+
+- Navigate to the demo page provided by the module at `/admin/states`.
+- Use the provided links to set a new value or delete the current value stored in the state.
+
+## Customization
+
+### State Plugin
+The custom state plugin is defined in `src/Plugin/State/CustomState.php`. This file contains the logic for managing the custom state.
+
+### State Manager
+The state manager is defined in `src/State/StateManager.php`. This file contains the logic for handling state-related operations.
+
+### Controller
+The controller is defined in `src/Controller/StateDemoController.php`. This file contains the logic for the demo page, including setting and deleting state values.
+
+## Configuration
+The module's services are defined in `vaibhav_state_api.services.yml`. This file registers the custom state plugin and state manager service.

--- a/vaibhav_state_api/src/Controller/StateDemoController.php
+++ b/vaibhav_state_api/src/Controller/StateDemoController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\vaibhav_state_api\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\HtmlCommand;
+
+/**
+ * Controller for the State API demo.
+ */
+class StateDemoController extends ControllerBase {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $customState;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructor for StateDemoController.
+   *
+   * @param \Drupal\Core\State\StateInterface $custom_state
+   *   The custom state service.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(StateInterface $custom_state, RequestStack $request_stack, MessengerInterface $messenger) {
+    $this->customState = $custom_state;
+    $this->requestStack = $request_stack;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('state'),
+      $container->get('request_stack'),
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Demo page.
+   */
+  public function demoPage() {
+    // Get the current request.
+    $request = $this->requestStack->getCurrentRequest();
+    $delete = $request->query->get('delete') === 'true';
+
+    // Get current value first (shows persistence between requests)
+    $current_value = $this->customState->get('vaibhav_demo_key');
+
+    if ($delete) {
+      // If delete parameter is set, delete the value.
+      $this->customState->delete('vaibhav_demo_key');
+      $this->messenger->addStatus($this->t('Value has been deleted!'));
+      $after_action = 'Value was deleted';
+    }
+    else {
+      // Otherwise, set a new value.
+      $new_value = date('Y-m-d H:i:s');
+      $this->customState->set('vaibhav_demo_key', $new_value);
+      $after_action = 'Value was set to: ' . $new_value;
+    }
+
+    // Get the value after our action.
+    $final_value = $this->customState->get('vaibhav_demo_key');
+
+    $response_data = [
+      'current_value' => $current_value ?? 'No value',
+      'after_action' => $after_action,
+      'final_value' => $final_value ?? 'No value',
+    ];
+
+    if ($request->isXmlHttpRequest()) {
+      $response = new AjaxResponse();
+      $response->addCommand(new HtmlCommand('.value-at-page-load', 'Value at page load: ' . $response_data['current_value']));
+      $response->addCommand(new HtmlCommand('.action-performed', 'Action performed: ' . $response_data['after_action']));
+      $response->addCommand(new HtmlCommand('.value-after-action', 'Value after action: ' . $response_data['final_value']));
+      return $response;
+    }
+
+    $build = [
+      '#type' => 'markup',
+      '#markup' => $this->t('
+        <h2>State API Demo</h2>
+        <p class="value-at-page-load">Value at page load: @current</p>
+        <p class="action-performed">Action performed: @action</p>
+        <p class="value-after-action">Value after action: @final</p>
+        <p><a href="/admin/states" class="use-ajax">Set new value</a> | <a href="/admin/states?delete=true" class="use-ajax">Delete value</a></p>
+      ', [
+        '@current' => $current_value ?? 'No value',
+        '@action' => $after_action,
+        '@final' => $final_value ?? 'No value',
+      ]),
+      '#attached' => [
+        'library' => [
+          'core/drupal.ajax',
+          'vaibhav_state_api/demo',
+        ],
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/vaibhav_state_api/src/Plugin/State/CustomState.php
+++ b/vaibhav_state_api/src/Plugin/State/CustomState.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\vaibhav_state_api\Plugin\State;
+
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\vaibhav_state_api\State\StateManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a custom state manager.
+ *
+ * @State(
+ *   id = "custom_state",
+ *   label = @Translation("Custom State Manager"),
+ *   category = "custom_states"
+ * )
+ */
+class CustomState extends PluginBase implements StateInterface {
+  // Due we are implementing StateInterface we need to implement
+  // all the methods from the interface.
+  // Like get, set, delete, getMultiple, setMultiple,
+  // deleteMultiple and resetCache.
+  /**
+   * The state manager.
+   *
+   * @var \Drupal\vaibhav_state_api\State\StateManager
+   */
+  protected $manager;
+
+  /**
+   * Constructs a CustomState object.
+   *
+   * @param array $configuration
+   *   A configuration array containing plugin instance information.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\vaibhav_state_api\State\StateManager $manager
+   *   The state manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StateManager $manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->manager = $manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('vaibhav_state_api.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($key, $default = NULL) {
+    return $this->manager->get($key) ?? $default;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function set($key, $value) {
+    $this->manager->set($key, $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($key) {
+    $this->manager->delete($key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMultiple($keys) {
+    $values = [];
+    foreach ($keys as $key) {
+      $values[$key] = $this->get($key);
+    }
+    return $values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setMultiple(array $values) {
+    foreach ($values as $key => $value) {
+      $this->set($key, $value);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteMultiple(array $keys) {
+    foreach ($keys as $key) {
+      $this->delete($key);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resetCache() {
+    // Implement cache reset if needed.
+  }
+
+}

--- a/vaibhav_state_api/src/State/StateManager.php
+++ b/vaibhav_state_api/src/State/StateManager.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\vaibhav_state_api\State;
+
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+
+/**
+ * State manager for custom state storage.
+ */
+class StateManager {
+
+  /**
+   * The key value factory.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueFactoryInterface
+   */
+  protected $keyValue;
+
+  /**
+   * Constructs a StateManager object.
+   *
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value
+   *   The key value factory.
+   */
+  public function __construct(KeyValueFactoryInterface $key_value) {
+    $this->keyValue = $key_value;
+  }
+
+  /**
+   * Gets a value from storage.
+   *
+   * @param string $key
+   *   The key to retrieve.
+   *
+   * @return mixed
+   *   The stored value, or NULL if not found.
+   */
+  public function get($key) {
+    return $this->keyValue->get('vaibhav_state')->get($key);
+  }
+
+  /**
+   * Sets a value in storage.
+   *
+   * @param string $key
+   *   The key to set.
+   * @param mixed $value
+   *   The value to store.
+   */
+  public function set($key, $value) {
+    $this->keyValue->get('vaibhav_state')->set($key, $value);
+  }
+
+  /**
+   * Deletes a value from storage.
+   *
+   * @param string $key
+   *   The key to delete.
+   */
+  public function delete($key) {
+    $this->keyValue->get('vaibhav_state')->delete($key);
+  }
+
+}

--- a/vaibhav_state_api/vaibhav_state_api.field_type_categories.yml
+++ b/vaibhav_state_api/vaibhav_state_api.field_type_categories.yml
@@ -1,0 +1,3 @@
+custom_states:
+  label: 'Custom States'
+  description: 'State management implementations provided by the module'

--- a/vaibhav_state_api/vaibhav_state_api.info.yml
+++ b/vaibhav_state_api/vaibhav_state_api.info.yml
@@ -1,0 +1,5 @@
+name: Vaibhav State API
+type: module
+description: 'Custom state management implementation'
+package: Vaibhav
+core_version_requirement: ^11

--- a/vaibhav_state_api/vaibhav_state_api.libraries.yml
+++ b/vaibhav_state_api/vaibhav_state_api.libraries.yml
@@ -1,0 +1,8 @@
+demo:
+  version: 1.x
+  js:
+    js/vaibhav_state_api.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupal.ajax

--- a/vaibhav_state_api/vaibhav_state_api.module
+++ b/vaibhav_state_api/vaibhav_state_api.module
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Contains hooks related to vaibhav_state_api module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function vaibhav_state_api_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.vaibhav_state_api':
+      $output = '<h3>' . t('Vaibhav State API') . '</h3>';
+      $output .= '<p>' . t('Demonstration page: <a href=":url">State API Demo</a>', [
+        ':url' => \Drupal::url('vaibhav_state_api.demo'),
+      ]) . '</p>';
+      return $output;
+  }
+}
+
+/**
+ * Implements hook_library_info_build().
+ */
+function vaibhav_state_api_library_info_build() {
+  return [
+    'demo' => [
+      'version' => '1.0',
+      'css' => [
+        'theme' => [
+          'css/vaibhav-state-api.css' => [],
+        ],
+      ],
+    ],
+  ];
+}

--- a/vaibhav_state_api/vaibhav_state_api.routing.yml
+++ b/vaibhav_state_api/vaibhav_state_api.routing.yml
@@ -1,0 +1,10 @@
+vaibhav_state_api.demo:
+  path: '/admin/states'
+  defaults:
+    _controller: '\Drupal\vaibhav_state_api\Controller\StateDemoController::demoPage'
+    _title: 'State API Demo'
+  requirements:
+    _permission: 'access content'
+  options:
+    _format: 'json'
+    _no_cache: 'TRUE'

--- a/vaibhav_state_api/vaibhav_state_api.services.yml
+++ b/vaibhav_state_api/vaibhav_state_api.services.yml
@@ -1,0 +1,14 @@
+services:
+  vaibhav_state_api.manager:
+    class: Drupal\vaibhav_state_api\State\StateManager
+    arguments: ['@keyvalue']
+
+  state.custom_state:
+    class: Drupal\vaibhav_state_api\Plugin\State\CustomState
+    arguments:
+      - []
+      - 'custom_state'
+      - null
+      - '@vaibhav_state_api.manager'
+    tags:
+      - { name: state, category: custom_states }


### PR DESCRIPTION

## Installation

1. Download and place the `vaibhav_state_api` module in your Drupal site's `modules/custom` directory.
2. Enable the module using the following Drush command:
   ```sh
   drush en vaibhav_state_api
   ```
   Or enable it through the Drupal admin interface.

## Usage

- Navigate to the demo page provided by the module at `/admin/states`.
- Use the provided links to set a new value or delete the current value stored in the state.
