### PR TITLE
feat(block_api): Custom Block API  implementation

### DIFF
--- a/vaibhav_block_api/README.md
+++ b/vaibhav_block_api/README.md
@@ -1,0 +1,25 @@
+# Vaibhav Block API
+
+## Introduction
+A simple Drupal 11 custom module that provides a Custom block which can be placed anywhere on your Drupal site.
+
+## Requirements
+- Drupal 11
+- Block module (core)
+
+## Installation
+1. Place the module folder in `web/modules/custom/` directory
+2. Enable the module via Drush: `drush en vaibhav_block_api` or through the admin UI at `/admin/modules`
+3. Clear cache: `drush cr`
+
+## Usage
+1. Go to Block layout: `/admin/structure/block`
+2. Click "Place block" in the region where you want the block to appear
+3. Search for "Namaste Bharat Block"
+4. Click "Place block" and configure as needed
+5. Save the block placement
+
+## Module Structure
+- `vaibhav_block_api.info.yml`: Module definition and dependencies
+- `vaibhav_block_api.module`: Hook implementations
+- `src/Plugin/Block/NamasteBharat.php`: Block plugin class

--- a/vaibhav_block_api/src/Plugin/Block/NamasteBharat.php
+++ b/vaibhav_block_api/src/Plugin/Block/NamasteBharat.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\vaibhav_block_api\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Namaste Bharat' block.
+ *
+ * @Block(
+ *   id = "namaste_bharat_block",
+ *   admin_label = @Translation("Namaste Bharat Block"),
+ *   category = @Translation("Vaibhav")
+ * )
+ */
+class NamasteBharat extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#markup' => $this->t('Namaste, Bharat!'),
+    ];
+  }
+
+}

--- a/vaibhav_block_api/vaibhav_block_api.info.yml
+++ b/vaibhav_block_api/vaibhav_block_api.info.yml
@@ -1,0 +1,7 @@
+name: 'Vaibhav Block API'
+type: module
+description: 'A simple Custom block for Drupal 11.'
+core_version_requirement: ^11 || ^10
+package: Vaibhav
+dependencies:
+  - drupal:block

--- a/vaibhav_block_api/vaibhav_block_api.module
+++ b/vaibhav_block_api/vaibhav_block_api.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains vaibhav_block_api.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function vaibhav_block_api_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.vaibhav_block_api':
+      \Drupal::messenger()->addMessage(t('This module provides a Namaste Bharat block.'));
+      break;
+  }
+}


### PR DESCRIPTION

## Introduction
A simple Drupal 11 custom module that provides a Custom block which can be placed anywhere on your Drupal site.

## Installation
1. Place the module folder in `web/modules/custom/` directory
2. Enable the module via Drush: `drush en vaibhav_block_api` or through the admin UI at `/admin/modules`
3. Clear cache: `drush cr`

## Usage
1. Go to Block layout: `/admin/structure/block`
2. Click "Place block" in the region where you want the block to appear
3. Search for "Namaste Bharat Block"
4. Click "Place block" and configure as needed
5. Save the block placement
