### PR TITLE
feat(config_api): add Config API module for dynamic footer text config

### DIFF
--- a/vaibhav_config_api/README.md
+++ b/vaibhav_config_api/README.md
@@ -1,0 +1,31 @@
+# Config API
+
+## Overview
+TO add new option in the admin config form `/admin/config`
+
+## Features
+- Admin form to set and update footer text.
+- Displays the footer text dynamically on the website.
+
+## Installation
+
+### Step 0: Paste in the modules folder
+Add this folder in the `/modules/custom` folder of your drupal project.
+
+### Step 1: Enable the Module
+Run the following command:
+```bash
+drush en vaibhav_config_api -y
+```
+Or enable it through the Drupal UI:
+1. Navigate to **Extend** (`/admin/modules`).
+2. Find **Vaibhav Config API** and enable it.
+3. In your **page.html.twig** file add below line inside footer.
+```php
+{{ footer_txt }}
+```
+
+### Step 2: Configure Footer Text
+1. Navigate to **Configuration** → **Vaibhav Config API Settings** (`/admin/config/vaibhav-config-api`).
+2. Enter the text you want to display in the footer.
+3. Click **Save Configuration**.

--- a/vaibhav_config_api/config/install/vaibhav_config_api.settings.yml
+++ b/vaibhav_config_api/config/install/vaibhav_config_api.settings.yml
@@ -1,0 +1,1 @@
+footer_text: 'Default footer text'

--- a/vaibhav_config_api/src/Form/ConfigApiForm.php
+++ b/vaibhav_config_api/src/Form/ConfigApiForm.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\vaibhav_config_api\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure settings for the Vaibhav Config API.
+ */
+class ConfigApiForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['vaibhav_config_api.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'vaibhav_config_api_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('vaibhav_config_api.settings');
+
+    $form['footer_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Footer Text'),
+      '#default_value' => $config->get('footer_text'),
+      '#description' => $this->t('Enter the text to be displayed in the footer.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('vaibhav_config_api.settings')
+      ->set('footer_text', $form_state->getValue('footer_text'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/vaibhav_config_api/templates/footer-text.html.twig
+++ b/vaibhav_config_api/templates/footer-text.html.twig
@@ -1,0 +1,3 @@
+<div class="site-footer">
+  <p>{{ footer_txt }}</p>
+</div>

--- a/vaibhav_config_api/vaibhav_config_api.info.yml
+++ b/vaibhav_config_api/vaibhav_config_api.info.yml
@@ -1,0 +1,7 @@
+name: 'vaibhav_config_api'
+type: module
+description: 'A module for Configuration API in drupal'
+package: Vaibhav
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:config

--- a/vaibhav_config_api/vaibhav_config_api.module
+++ b/vaibhav_config_api/vaibhav_config_api.module
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * To display the text in the footer.
+ */
+
+/**
+ * Implements hook_preprocess_HOOK() for page templates.
+ */
+function vaibhav_config_api_preprocess_page(array &$variables) {
+  $config = \Drupal::config('vaibhav_config_api.settings');
+  $variables['footer_txt'] = $config->get('footer_text');
+}

--- a/vaibhav_config_api/vaibhav_config_api.routing.yml
+++ b/vaibhav_config_api/vaibhav_config_api.routing.yml
@@ -1,0 +1,7 @@
+vaibhav_config_api.settings:
+  path: '/admin/config/vaibhav-config-api'
+  defaults:
+    _form: '\Drupal\vaibhav_config_api\Form\ConfigApiForm'
+    _title: 'Vaibhav Config API Settings'
+  requirements:
+    _permission: 'administer site configuration'


### PR DESCRIPTION

## Installation

### Step 0: Paste in the modules folder
Add this folder in the `/modules/custom` folder of your drupal project.

### Step 1: Enable the Module
Run the following command:
```bash
drush en vaibhav_config_api -y
```
Or enable it through the Drupal UI:
1. Navigate to **Extend** (`/admin/modules`).
2. Find **Vaibhav Config API** and enable it.
3. In your **page.html.twig** file add below line inside footer.
```php
{{ footer_txt }}
```

### Step 2: Configure Footer Text
1. Navigate to **Configuration** → **Vaibhav Config API Settings** (`/admin/config/vaibhav-config-api`).
2. Enter the text you want to display in the footer.
3. Click **Save Configuration**.
