### PR TITLE
feat(routes_controllers): add custom module with static and dynamic routes

### DIFF
--- a/vaibhav_routes_controllers/README.md
+++ b/vaibhav_routes_controllers/README.md
@@ -1,0 +1,37 @@
+# Vaibhav Routes & Controllers
+
+## Overview
+- A **simple route** that returns a static message.
+- A **dynamic route** that accepts a parameter and displays a personalized message.
+
+## Installation
+
+### Step 1: Enable the Module
+Run the following command:
+```bash
+drush en vaibhav_routes_controllers -y
+```
+
+## How It Works
+
+### Defined Routes
+- `/static` → Displays a static message.
+- `/dynamic/{name}` → Accepts a name parameter and displays a personalized message.
+
+### Controller (`VaibhavController`)
+- Handles **HTTP GET** requests.
+- Returns responses as Drupal **render arrays**.
+
+## Testing the Module
+1. **Clear cache:**
+   ```bash
+   drush cr
+   ```
+2. **Visit the simple route:**
+   ```
+   /static
+   ```
+3. **Visit the dynamic route:**
+   ```
+   /dynamic/Vaibhav
+   ```

--- a/vaibhav_routes_controllers/src/Controller/VaibhavController.php
+++ b/vaibhav_routes_controllers/src/Controller/VaibhavController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\vaibhav_routes_controllers\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Controller for route demonstrations.
+ */
+class VaibhavController extends ControllerBase {
+
+  /**
+   * Returns a simple message.
+   */
+  public function simpleMessage() {
+    return [
+      '#markup' => '<p>Welcome This is a college website developed by Vaibhav during the learning phase of Drupal!</p>',
+    ];
+  }
+
+  /**
+   * Returns a personalized message using a dynamic parameter.
+   */
+  public function dynamicMessage($name) {
+    return [
+      '#markup' => "<p>Hello, <strong>$name</strong>! This is a dynamic route.</p>",
+    ];
+  }
+
+}

--- a/vaibhav_routes_controllers/vaibhav_routes_controllers.info.yml
+++ b/vaibhav_routes_controllers/vaibhav_routes_controllers.info.yml
@@ -1,0 +1,7 @@
+name: 'vaibhav_routes_controllers'
+type: module
+description: 'Demonstrates routes and controllers in Drupal 11.'
+package: Vaibhav
+core_version_requirement: ^10 || ^11
+dependencies:
+  - drupal:system

--- a/vaibhav_routes_controllers/vaibhav_routes_controllers.routing.yml
+++ b/vaibhav_routes_controllers/vaibhav_routes_controllers.routing.yml
@@ -1,0 +1,17 @@
+vaibhav_routes_controllers.simple_route:
+  path: '/static'
+  defaults:
+    _controller: '\Drupal\vaibhav_routes_controllers\Controller\VaibhavController::simpleMessage'
+    _title: 'Simple Route'
+  methods: [GET]
+  requirements:
+    _permission: 'access content'
+
+vaibhav_routes_controllers.dynamic_route:
+  path: '/dynamic/{name}'
+  defaults:
+    _controller: '\Drupal\vaibhav_routes_controllers\Controller\VaibhavController::dynamicMessage'
+    _title: 'Dynamic Route'
+  methods: [GET]
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
## Overview
- A **simple route** that returns a static message.
- A **dynamic route** that accepts a parameter and displays a personalized message.


## Installation

### Step 1: Enable the Module
Run the following command:
```bash
drush en vaibhav_routes_controllers -y
```

## How It Works

### Defined Routes
- `/static` → Displays a static message.
- `/dynamic/{name}` → Accepts a name parameter and displays a personalized message.
