### PR TITLE
feat:(omkar_fieldapi):created a custom color picker using field api

### DIFF
--- a/omkar_fieldapi/omkar_fieldapi.info.yml
+++ b/omkar_fieldapi/omkar_fieldapi.info.yml
@@ -1,0 +1,7 @@
+name: 'Omkar Field api'
+type: module
+description: 'Custom RGB color field using Field API..'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - field

--- a/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldFormatter(
+  id: "color_rgb_formatter",
+  label: new TranslatableMarkup("Color RGB Formatter"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldFormatter extends FormatterBase {
+
+  /**
+   *
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $color = sprintf("#%02x%02x%02x", $item->red, $item->green, $item->blue);
+
+      // Return the color value as plain markup or use a custom render array.
+      $elements[$delta] = [
+        '#markup' => $color,
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldType(
+  id: "color_rgb",
+  label: new TranslatableMarkup("Color RGB"),
+  description: new TranslatableMarkup("Stores a color in RGB format."),
+  default_widget: "color_rgb_widget",
+  default_formatter: "color_rgb_formatter"
+)]
+class ColorFieldItem extends FieldItemBase {
+
+  /**
+   *
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+    $properties['red'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Red value'));
+    $properties['green'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Green value'));
+    $properties['blue'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Blue value'));
+    return $properties;
+  }
+
+  /**
+   *
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+    return [
+      'columns' => [
+        'red' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'green' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'blue' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+      ],
+    ];
+  }
+
+  /**
+   *
+   */
+  public function isEmpty(): bool {
+    return $this->get('red')->getValue() === NULL &&
+           $this->get('green')->getValue() === NULL &&
+           $this->get('blue')->getValue() === NULL;
+  }
+
+}

--- a/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[FieldWidget(
+  id: "color_rgb_widget",
+  label: new TranslatableMarkup("Color RGB Widget"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldWidget extends WidgetBase {
+
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element['red'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Red'),
+      '#default_value' => $items[$delta]->red ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['green'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Green'),
+      '#default_value' => $items[$delta]->green ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['blue'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Blue'),
+      '#default_value' => $items[$delta]->blue ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    return $element;
+  }
+
+}

--- a/omkar_formapi/omkar_formapi.info.yml
+++ b/omkar_formapi/omkar_formapi.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Custom module to explore Form API with AJAX and submission preview.'
 core_version_requirement: ^11
 package: Custom
+dependencies:
+  - omkar_pluginapi

--- a/omkar_formapi/src/Form/OmkarFormApiForm.php
+++ b/omkar_formapi/src/Form/OmkarFormApiForm.php
@@ -6,8 +6,39 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\omkar_pluginapi\OmkarPluginapiPluginManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class OmkarFormApiForm extends ConfigFormBase {
+
+  protected $pluginManager;
+  protected $database;
+  protected $messenger;
+  protected $dateFormatter;
+
+  public function __construct(
+    OmkarPluginapiPluginManager $plugin_manager,
+    Connection $database,
+    MessengerInterface $messenger,
+    DateFormatterInterface $date_formatter
+  ) {
+    $this->pluginManager = $plugin_manager;
+    $this->database = $database;
+    $this->messenger = $messenger;
+    $this->dateFormatter = $date_formatter;
+  }
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.omkar_pluginapi'),
+      $container->get('database'),
+      $container->get('messenger'),
+      $container->get('date.formatter')
+    );
+  }
 
   public function getFormId() {
     return 'omkar_formapi_form';
@@ -16,18 +47,15 @@ class OmkarFormApiForm extends ConfigFormBase {
   protected function getEditableConfigNames() {
     return ['omkar_formapi.settings'];
   }
-  
+
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $schema = $this->database->schema();
+    if (!$schema->tableExists('omkar_formapi_data')) {
+      $this->messenger->addError('Table does NOT exist!');
+    } else {
+      $this->messenger->addStatus('Table exists ✅');
+    }
 
-    /////////////////////////////////
-    $schema = \Drupal::database()->schema();
-if (!$schema->tableExists('omkar_formapi_data')) {
-  \Drupal::messenger()->addError('Table does NOT exist!');
-} else {
-  \Drupal::messenger()->addStatus('Table exists ✅');
-}
-
-    /////////////////////////////////
     $config = $this->config('omkar_formapi.settings');
 
     $form['name'] = [
@@ -68,6 +96,21 @@ if (!$schema->tableExists('omkar_formapi_data')) {
       '#markup' => '<div id="preview-wrapper">' . $this->renderPreview($form_state) . '</div>',
     ];
 
+    $plugins = $this->pluginManager->getDefinitions();
+    $form['plugin_sandwich_list'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Available Sandwich Plugins 🍔'),
+      '#open' => TRUE,
+    ];
+
+    foreach ($plugins as $plugin_id => $definition) {
+      $form['plugin_sandwich_list'][$plugin_id] = [
+        '#type' => 'item',
+        '#title' => $definition['label'],
+        '#markup' => '<p>' . $definition['description'] . '</p><p><strong>Calories:</strong> ' . $definition['calories'] . '</p>',
+      ];
+    }
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -86,35 +129,23 @@ if (!$schema->tableExists('omkar_formapi_data')) {
     return '<div><h4>Live Preview:</h4><p><strong>Name:</strong> ' . $name . '</p><p><strong>Email:</strong> ' . $email . '</p><p><strong>Message:</strong> ' . $message . '</p></div>';
   }
 
-  // public function submitForm(array &$form, FormStateInterface $form_state) {
-  //   $this->config('omkar_formapi.settings')
-  //     ->set('name', $form_state->getValue('name'))
-  //     ->set('email', $form_state->getValue('email'))
-  //     ->set('message', $form_state->getValue('message'))
-  //     ->save();
-
-  //   parent::submitForm($form, $form_state);
-  // }
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    // Save to custom table.
-    \Drupal::database()->insert('omkar_formapi_data')
-    ->fields([
-      'name' => $form_state->getValue('name'),
-      'email' => $form_state->getValue('email'),
-      'message' => $form_state->getValue('message'),
-      'created' => \Drupal::time()->getCurrentTime(),
-    ])
-    ->execute();
-  
-  
-    // Optionally also save to config.
+    $this->database->insert('omkar_formapi_data')
+      ->fields([
+        'name' => $form_state->getValue('name'),
+        'email' => $form_state->getValue('email'),
+        'message' => $form_state->getValue('message'),
+        'created' => time(), // You can use PHP time() or inject Time service separately
+      ])
+      ->execute();
+
     $this->config('omkar_formapi.settings')
       ->set('name', $form_state->getValue('name'))
       ->set('email', $form_state->getValue('email'))
       ->set('message', $form_state->getValue('message'))
       ->save();
-  
+
     parent::submitForm($form, $form_state);
   }
-  
+
 }

--- a/omkar_formapi/src/Plugin/OmkarPluginapi/ChickenSandwich.php
+++ b/omkar_formapi/src/Plugin/OmkarPluginapi/ChickenSandwich.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_formapi\Plugin\OmkarPluginapi;
+
+use Drupal\omkar_pluginapi\OmkarPluginapiPluginBase;
+
+/**
+ * Provides a Chicken Sandwich plugin.
+ *
+ * @OmkarPluginapi(
+ *   id = "chicken_sandwich",
+ *   label = @Translation("Chicken Sandwich"),
+ *   description = @Translation("A protein-rich grilled chicken sandwich."),
+ *   calories = 450
+ * )
+ */
+class ChickenSandwich extends OmkarPluginapiPluginBase {
+  // Inherits all methods: label(), description(), calories().
+  // You can override them here if needed.
+}

--- a/omkar_pluginapi/omkar_pluginapi.info.yml
+++ b/omkar_pluginapi/omkar_pluginapi.info.yml
@@ -1,0 +1,5 @@
+name: 'omkar_pluginapi'
+type: module
+description: 'Demo plugin api demo'
+package: Custom
+core_version_requirement: ^10 || ^11

--- a/omkar_pluginapi/omkar_pluginapi.routing.yml
+++ b/omkar_pluginapi/omkar_pluginapi.routing.yml
@@ -1,0 +1,7 @@
+omkar_pluginapi.show_plugins:
+  path: '/omkar-pluginapi'
+  defaults:
+    _controller: '\Drupal\omkar_pluginapi\Controller\OmkarPluginapiController::showPlugins'
+    _title: 'Omkar PluginAPI Sandwiches'
+  requirements:
+    _permission: 'access content'

--- a/omkar_pluginapi/omkar_pluginapi.services.yml
+++ b/omkar_pluginapi/omkar_pluginapi.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.omkar_pluginapi:
+    class: Drupal\omkar_pluginapi\OmkarPluginapiPluginManager
+    arguments: ['@container.namespaces', '@cache.default', '@module_handler']

--- a/omkar_pluginapi/src/Annotation/OmkarPluginapi.php
+++ b/omkar_pluginapi/src/Annotation/OmkarPluginapi.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_pluginapi\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines omkar_pluginapi annotation object.
+ *
+ * @Annotation
+ */
+final class OmkarPluginapi extends Plugin {
+
+  /**
+   * The plugin ID.
+   */
+  public readonly string $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @ingroup plugin_translatable
+   */
+  public readonly string $title;
+
+  /**
+   * The description of the plugin.
+   *
+   * @ingroup plugin_translatable
+   */
+  public readonly string $description;
+
+  /**
+   * The number of calories per serving of this sandwich type.
+   *
+   * This property is a float value, so we indicate that to other developers
+   * who are writing annotations for a Sandwich plugin.
+   *
+   * @var int
+   */
+  public $calories;
+
+}

--- a/omkar_pluginapi/src/Controller/OmkarPluginapiController.php
+++ b/omkar_pluginapi/src/Controller/OmkarPluginapiController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\omkar_pluginapi\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\omkar_pluginapi\OmkarPluginapiPluginManager;
+
+class OmkarPluginapiController extends ControllerBase {
+
+  protected $pluginManager;
+
+  public function __construct(OmkarPluginapiPluginManager $pluginManager) {
+    $this->pluginManager = $pluginManager;
+  }
+
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.omkar_pluginapi')
+    );
+  }
+
+  // public function showPlugins() {
+  //   $build = [];
+  //   $definitions = $this->pluginManager->getDefinitions();
+  //   foreach ($definitions as $id => $plugin_def) {
+  //     $plugin = $this->pluginManager->createInstance($id);
+  //     // DO NOT use $this->t() if you want raw HTML or JS to work.
+  //     $build[] = [
+  //       '#markup' => '<h3>' . $plugin->label() . '</h3><p>' . $plugin->description() . '</p><p>Calories: ' . $plugin->calories() . '</p>',
+  //     ];
+  //   }
+  //   return $build;
+  // }
+  public function showPlugins() {
+    $build = [];
+
+    $definitions = $this->pluginManager->getDefinitions();
+
+    foreach ($definitions as $id => $plugin_def) {
+      $plugin = $this->pluginManager->createInstance($id);
+
+      $build[] = [
+        '#markup' => $this->t('<h3>@label</h3><p>@desc</p><p>Calories: @cal</p>', [
+          '@label' => $plugin->label(),
+          '@desc' => $plugin->description(),
+          '@cal' => $plugin->calories(),
+        ]),
+//         '#markup' => $this->t('<h3>!label</h3><p>!desc</p><p>Calories: @cal</p>', [
+//   '!label' => $plugin->label(),
+//   '!desc' => $plugin->description(),
+//   '@cal' => $plugin->calories(),
+// ]),
+      ];
+    }
+
+    return $build;
+  }
+}

--- a/omkar_pluginapi/src/OmkarPluginapiInterface.php
+++ b/omkar_pluginapi/src/OmkarPluginapiInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_pluginapi;
+
+/**
+ * Interface for omkar_pluginapi plugins.
+ */
+interface OmkarPluginapiInterface {
+
+  /**
+   * Provide a description of the sandwich.
+   *
+   * @return string
+   *   A string description of the sandwich.
+   */
+  public function description();
+
+  /**
+   * Provide the number of calories per serving for the sandwich.
+   *
+   * @return float
+   *   The number of calories per serving.
+   */
+  public function calories();
+
+  /**
+   * Returns the translated plugin label.
+   */
+  public function label(): string;
+
+}

--- a/omkar_pluginapi/src/OmkarPluginapiPluginBase.php
+++ b/omkar_pluginapi/src/OmkarPluginapiPluginBase.php
@@ -17,26 +17,24 @@ abstract class OmkarPluginapiPluginBase extends PluginBase implements OmkarPlugi
   public function label(): string {
     return (string) $this->pluginDefinition['label'];
   }
-  
+
   /**
    * {@inheritdoc}
    */
-  public function description()
-  {
+  public function description() {
     return $this->pluginDefinition['description'];
   }
 
-    /**
-     * {@inheritdoc}
-     */
-  public function calories()
-  {
-    return $this->pluginDefinition['calories'];
-    
-  }
-
-   /**
+  /**
    * {@inheritdoc}
    */
-  // abstract public function order(array $extras);
+  public function calories() {
+    return $this->pluginDefinition['calories'];
+
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  // Abstract public function order(array $extras);.
 }

--- a/omkar_pluginapi/src/OmkarPluginapiPluginBase.php
+++ b/omkar_pluginapi/src/OmkarPluginapiPluginBase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_pluginapi;
+
+use Drupal\Component\Plugin\PluginBase;
+
+/**
+ * Base class for omkar_pluginapi plugins.
+ */
+abstract class OmkarPluginapiPluginBase extends PluginBase implements OmkarPluginapiInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label(): string {
+    return (string) $this->pluginDefinition['label'];
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function description()
+  {
+    return $this->pluginDefinition['description'];
+  }
+
+    /**
+     * {@inheritdoc}
+     */
+  public function calories()
+  {
+    return $this->pluginDefinition['calories'];
+    
+  }
+
+   /**
+   * {@inheritdoc}
+   */
+  // abstract public function order(array $extras);
+}

--- a/omkar_pluginapi/src/OmkarPluginapiPluginManager.php
+++ b/omkar_pluginapi/src/OmkarPluginapiPluginManager.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\omkar_pluginapi;
 
-//Interface for Drupal's caching system.Used to cache plugin discovery results.
-use Drupal\Core\Cache\CacheBackendInterface; 
+// Interface for Drupal's caching system.Used to cache plugin discovery results.
+use Drupal\Core\Cache\CacheBackendInterface;
 
-//Interface for interacting with enabled modules.Helps call hook implementations or alter functions.
+// Interface for interacting with enabled modules.Helps call hook implementations or alter functions.
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
 // Base class for most plugin managers in Drupal.
@@ -27,28 +27,31 @@ final class OmkarPluginapiPluginManager extends DefaultPluginManager {
    * Constructs the object.
    */
 
-//    \Traversable $namespaces
-// A list of available namespaces in the codebase.
-// Used to scan for plugin classes in subdirectories like Plugin/OmkarPluginapi.
-// CacheBackendInterface $cache_backend
-// Drupal's cache backend service.
-// Used to store plugin discovery results for performance.
-// ModuleHandlerInterface $module_handler
-// Service to interact with Drupal modules.
-// Used to run hook implementations or alter plugin definitions.
+  // \Traversable $namespaces
+  // A list of available namespaces in the codebase.
+  // Used to scan for plugin classes in subdirectories like Plugin/OmkarPluginapi.
+  // CacheBackendInterface $cache_backend
+  // Drupal's cache backend service.
+  // Used to store plugin discovery results for performance.
+  // ModuleHandlerInterface $module_handler
+  // Service to interact with Drupal modules.
+
+  /**
+   * Used to run hook implementations or alter plugin definitions.
+   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-// 'Plugin/OmkarPluginapi' → folder path to look for plugins.
-// $namespaces → namespaces to search within.
-// $module_handler → for alter hooks.
-// OmkarPluginapiInterface::class → expected interface plugins must implement.
-// OmkarPluginapi::class → annotation class used for discovery.
+    // 'Plugin/OmkarPluginapi' → folder path to look for plugins.
+    // $namespaces → namespaces to search within.
+    // $module_handler → for alter hooks.
+    // OmkarPluginapiInterface::class → expected interface plugins must implement.
+    // OmkarPluginapi::class → annotation class used for discovery.
     parent::__construct('Plugin/OmkarPluginapi', $namespaces, $module_handler, OmkarPluginapiInterface::class, OmkarPluginapi::class);
     // Enables hook_alter support.
     $this->alterInfo('omkar_pluginapi_info');
 
-//     $this->setCacheBackend($cache_backend, 'omkar_pluginapi_plugins');
-// Sets up caching for plugin discovery.
-// 'omkar_pluginapi_plugins' is the cache bin name (unique ID for storing cache entries).
+    // $this->setCacheBackend($cache_backend, 'omkar_pluginapi_plugins');
+    // Sets up caching for plugin discovery.
+    // 'omkar_pluginapi_plugins' is the cache bin name (unique ID for storing cache entries).
     $this->setCacheBackend($cache_backend, 'omkar_pluginapi_plugins');
   }
 

--- a/omkar_pluginapi/src/OmkarPluginapiPluginManager.php
+++ b/omkar_pluginapi/src/OmkarPluginapiPluginManager.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_pluginapi;
+
+//Interface for Drupal's caching system.Used to cache plugin discovery results.
+use Drupal\Core\Cache\CacheBackendInterface; 
+
+//Interface for interacting with enabled modules.Helps call hook implementations or alter functions.
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+// Base class for most plugin managers in Drupal.
+// Provides core logic for plugin discovery, instantiation, caching, etc.
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+// This is your custom annotation class used to tag plugin classes.
+// Needed so Drupal knows how to read metadata from plugins.
+use Drupal\omkar_pluginapi\Annotation\OmkarPluginapi;
+
+/**
+ * OmkarPluginapi plugin manager.
+ */
+final class OmkarPluginapiPluginManager extends DefaultPluginManager {
+
+  /**
+   * Constructs the object.
+   */
+
+//    \Traversable $namespaces
+// A list of available namespaces in the codebase.
+// Used to scan for plugin classes in subdirectories like Plugin/OmkarPluginapi.
+// CacheBackendInterface $cache_backend
+// Drupal's cache backend service.
+// Used to store plugin discovery results for performance.
+// ModuleHandlerInterface $module_handler
+// Service to interact with Drupal modules.
+// Used to run hook implementations or alter plugin definitions.
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+// 'Plugin/OmkarPluginapi' → folder path to look for plugins.
+// $namespaces → namespaces to search within.
+// $module_handler → for alter hooks.
+// OmkarPluginapiInterface::class → expected interface plugins must implement.
+// OmkarPluginapi::class → annotation class used for discovery.
+    parent::__construct('Plugin/OmkarPluginapi', $namespaces, $module_handler, OmkarPluginapiInterface::class, OmkarPluginapi::class);
+    // Enables hook_alter support.
+    $this->alterInfo('omkar_pluginapi_info');
+
+//     $this->setCacheBackend($cache_backend, 'omkar_pluginapi_plugins');
+// Sets up caching for plugin discovery.
+// 'omkar_pluginapi_plugins' is the cache bin name (unique ID for storing cache entries).
+    $this->setCacheBackend($cache_backend, 'omkar_pluginapi_plugins');
+  }
+
+}

--- a/omkar_pluginapi/src/Plugin/OmkarPluginapi/SampleSandwich.php
+++ b/omkar_pluginapi/src/Plugin/OmkarPluginapi/SampleSandwich.php
@@ -6,23 +6,14 @@ namespace Drupal\omkar_pluginapi\Plugin\OmkarPluginapi;
 
 use Drupal\omkar_pluginapi\OmkarPluginapiPluginBase;
 
-// /**
-//  * @OmkarPluginapi(
-//  *   id = "sample_Sandwich",
-//  *   label = @Translation("Sample Sandwich"),
-//  *   description = @Translation("A tasty sample sandwich."),
-//  *   calories = 350
-//  * )
-//  */
 /**
  * @OmkarPluginapi(
- *   id = "malicious_sandwich",
- *   label = "<script>alert('XSS')</script>",
- *   description = "<img src=x onerror=alert('Hacked')>",
- *   calories = 999
+ *   id = "sample_Sandwich",
+ *   label = @Translation("Sample Sandwich"),
+ *   description = @Translation("A tasty sample sandwich."),
+ *   calories = 350
  * )
  */
 class SampleSandwich extends OmkarPluginapiPluginBase {
+
 }
-
-

--- a/omkar_pluginapi/src/Plugin/OmkarPluginapi/SampleSandwich.php
+++ b/omkar_pluginapi/src/Plugin/OmkarPluginapi/SampleSandwich.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_pluginapi\Plugin\OmkarPluginapi;
+
+use Drupal\omkar_pluginapi\OmkarPluginapiPluginBase;
+
+// /**
+//  * @OmkarPluginapi(
+//  *   id = "sample_Sandwich",
+//  *   label = @Translation("Sample Sandwich"),
+//  *   description = @Translation("A tasty sample sandwich."),
+//  *   calories = 350
+//  * )
+//  */
+/**
+ * @OmkarPluginapi(
+ *   id = "malicious_sandwich",
+ *   label = "<script>alert('XSS')</script>",
+ *   description = "<img src=x onerror=alert('Hacked')>",
+ *   calories = 999
+ * )
+ */
+class SampleSandwich extends OmkarPluginapiPluginBase {
+}
+
+


### PR DESCRIPTION
This pull request introduces a new custom module, omkar_fieldapi, which provides a custom field type for storing RGB color values using Drupal's Field API. The module includes a field type, widget, and formatter to allow users to input and display color values as RGB components.

Key Features:
-Field Type (color_rgb):
-Stores RGB values as separate red, green, and blue integers.
-Includes database schema definition for efficient storage.
-Implements isEmpty() to handle validation.
-Field Widget (color_rgb_widget):
-Provides numeric input fields for red, green, and blue components.
-Input range restricted from 0 to 255 for each color channel.
-Field Formatter (color_rgb_formatter):
-Outputs color value as a hexadecimal string (e.g., #ff9900).
-Uses #markup render array for simple display.
-Module Info File (omkar_fieldapi.info.yml):
-Registers the module with necessary metadata and dependencies.
-Requires Drupal core version ^11.


Testing Notes:
-Enable the omkar_fieldapi module.
-Add a new field of type "Color RGB" to any content type.
-Test the widget for proper input validation.
-
![Screenshot from 2025-04-10 08-37-43](https://github.com/user-attachments/assets/133df46c-1899-431b-98d3-f730a709aadf)
Confirm the formatter displays the correct hex color code.