### PR TITLE
feat:(omkar_hooks_events):implement custom event for tracking new blo…

### DIFF
--- a/omkar_hooks_events/omkar_hooks_events.info.yml
+++ b/omkar_hooks_events/omkar_hooks_events.info.yml
@@ -1,0 +1,5 @@
+name: 'Omkar Hooks & Events'
+type: module
+description: 'Implements hooks and event subscribers for blog site.'
+core_version_requirement: ^11
+package: Custom

--- a/omkar_hooks_events/omkar_hooks_events.module
+++ b/omkar_hooks_events/omkar_hooks_events.module
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @file
+ */
+
+use Drupal\omkar_hooks_events\Event\BlogPublishedEvent;
+use Drupal\node\NodeInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_node_presave().
+ */
+
+/**
+ * Implements hook_node_presave().
+ */
+function omkar_hooks_events_node_presave(Node $node) {
+  // Ensure it's a blog post.
+  if ($node->bundle() === 'blog') {
+
+    // Check if the field exists before accessing it.
+    if ($node->hasField('field_tag')) {
+      $tags = $node->get('field_tag')->getValue();
+
+      $specific_tag_id = 4;
+      $tag_exists = FALSE;
+
+      foreach ($tags as $tag) {
+        if ($tag['target_id'] == $specific_tag_id) {
+          $tag_exists = TRUE;
+          break;
+        }
+      }
+
+      if (!$tag_exists) {
+        $tags[] = ['target_id' => $specific_tag_id];
+        $node->set('field_tag', $tags);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function omkar_hooks_events_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id === 'node_blog_form') {
+    $form['omkar_custom_note'] = [
+      '#markup' => '<div class="messages messages--status">Note: Don’t forget to write catchy titles!</div>',
+      '#weight' => -10,
+    ];
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+
+/**
+ * Implements hook_entity_update().
+ */
+function omkar_hooks_events_entity_update($entity) {
+  if ($entity instanceof NodeInterface) {
+    // Check if the node is a blog and is published.
+    if ($entity->bundle() === 'blog' && $entity->isPublished()) {
+      $dispatcher = \Drupal::service('event_dispatcher');
+      $event = new BlogPublishedEvent($entity);
+      $dispatcher->dispatch($event, BlogPublishedEvent::EVENT_NAME);
+    }
+  }
+} 

--- a/omkar_hooks_events/omkar_hooks_events.services.yml
+++ b/omkar_hooks_events/omkar_hooks_events.services.yml
@@ -1,0 +1,6 @@
+services:
+  omkar_hooks_events.subscriber:
+    class: Drupal\omkar_hooks_events\EventSubscriber\OmkarHooksEventsSubscriber
+    arguments: ['@messenger', '@logger.factory']
+    tags:
+      - { name: event_subscriber }

--- a/omkar_hooks_events/src/Event/BlogPublishedEvent.php
+++ b/omkar_hooks_events/src/Event/BlogPublishedEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\omkar_hooks_events\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Drupal\node\NodeInterface;
+
+/**
+ * Event triggered when a blog is published.
+ */
+class BlogPublishedEvent extends Event {
+
+  public const EVENT_NAME = 'omkar_hooks_events.blog_published';
+
+  protected NodeInterface $node;
+
+  public function __construct(NodeInterface $node) {
+    $this->node = $node;
+  }
+
+  /**
+   *
+   */
+  public function getNode(): NodeInterface {
+    return $this->node;
+  }
+
+}

--- a/omkar_hooks_events/src/EventSubscriber/OmkarHooksEventsSubscriber.php
+++ b/omkar_hooks_events/src/EventSubscriber/OmkarHooksEventsSubscriber.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\omkar_hooks_events\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\omkar_hooks_events\Event\BlogPublishedEvent;
+use Drupal\Core\Messenger\MessengerInterface;
+use Psr\Log\LoggerInterface;
+// Use this instead of LoggerInterface.
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Event Subscriber for Omkar Hooks Events module.
+ */
+class OmkarHooksEventsSubscriber implements EventSubscriberInterface {
+  use StringTranslationTrait;
+
+  protected MessengerInterface $messenger;
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructor with correct logger factory handling.
+   */
+  public function __construct(MessengerInterface $messenger, LoggerChannelFactoryInterface $loggerFactory) {
+    $this->messenger = $messenger;
+    // Get module-specific logger.
+    $this->logger = $loggerFactory->get('omkar_hooks_events');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::REQUEST => ['onKernelRequest', 20],
+      'entity.insert' => ['onEntityInsert'],
+      BlogPublishedEvent::EVENT_NAME => ['onBlogPublished'],
+    ];
+  }
+
+  /**
+   * Respond to HTTP request event.
+   */
+  public function onKernelRequest(RequestEvent $event) {
+    $request = $event->getRequest();
+    if (str_contains($request->getRequestUri(), '/blog')) {
+      $this->logger->notice('Blog page was accessed.');
+    }
+  }
+
+  /**
+   * Respond to entity insert event.
+   */
+  public function onEntityInsert(GenericEvent $event) {
+    $this->logger->notice('Entity insert event triggered.');
+
+    $entity = $event->getSubject();
+
+    if ($entity instanceof EntityInterface && $entity->getEntityTypeId() === 'node' && $entity->bundle() === 'blog') {
+      $this->logger->notice('New blog post created: ' . $entity->label());
+    }
+  }
+
+  /**
+   * Event handler for blog publication.
+   */
+  public function onBlogPublished(BlogPublishedEvent $event) {
+    $node = $event->getNode();
+    $title = $node->getTitle();
+
+    // Display message in UI.
+    $this->messenger->addMessage($this->t('Blog titled "%title" has been published!', ['%title' => $title]));
+
+    // Log event.
+    $this->logger->info('Blog "%title" was published.', ['%title' => $title]);
+  }
+
+}


### PR DESCRIPTION
This pull request adds a custom module named omkar_hooks_events, which enhances blog functionality using Drupal hooks and the Event Subscriber pattern. It includes logic for automatic tag handling, UI messaging, and event-driven blog publication tracking.

Key Features:
-Event System Integration:
-Defines a custom event BlogPublishedEvent triggered upon blog publication.

Subscribes to multiple events:
-KernelEvents::REQUEST for logging blog page access.
-entity.insert for logging newly created blog nodes.
-omkar_hooks_events.blog_published for showing user messages and logging blog publications.

Hook Implementations:
-hook_node_presave():
-Automatically attaches a tag with a specific term ID to blog posts if not already assigned.
-hook_entity_update():
-Dispatches BlogPublishedEvent when a blog node is updated and is published.

hook_form_alter():
-Adds a custom reminder message to the blog node form to encourage engaging titles.

Service Definition:
-Registers OmkarHooksEventsSubscriber as an event subscriber.
-Injects messenger and a dedicated logger service for clean architecture.

Info File:
Declares module metadata and core compatibility with Drupal 11.

Testing Notes:
-Enable the omkar_hooks_events module.
-Create and update blog content to verify tag auto-assignment and event triggering.
-Visit a blog page and check log entries for access tracking.
-Ensure UI messages appear correctly upon blog publication.
![Screenshot from 2025-04-10 09-39-35](https://github.com/user-attachments/assets/cce9bd42-6ce1-43f0-8ab5-81782e879837)
