### PR TITLE
feat:(omkar_fieldapi):created a custom color picker using field api

### DIFF
--- a/omkar_fieldapi/omkar_fieldapi.info.yml
+++ b/omkar_fieldapi/omkar_fieldapi.info.yml
@@ -1,0 +1,7 @@
+name: 'Omkar Field api'
+type: module
+description: 'Custom RGB color field using Field API..'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - field

--- a/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldFormatter/ColorFieldFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\Attribute\FieldFormatter;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldFormatter(
+  id: "color_rgb_formatter",
+  label: new TranslatableMarkup("Color RGB Formatter"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldFormatter extends FormatterBase {
+
+  /**
+   *
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array {
+    $elements = [];
+
+    foreach ($items as $delta => $item) {
+      $color = sprintf("#%02x%02x%02x", $item->red, $item->green, $item->blue);
+
+      // Return the color value as plain markup or use a custom render array.
+      $elements[$delta] = [
+        '#markup' => $color,
+      ];
+    }
+
+    return $elements;
+  }
+
+}

--- a/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldType/ColorFieldItem.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\Attribute\FieldType;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ *
+ */
+#[FieldType(
+  id: "color_rgb",
+  label: new TranslatableMarkup("Color RGB"),
+  description: new TranslatableMarkup("Stores a color in RGB format."),
+  default_widget: "color_rgb_widget",
+  default_formatter: "color_rgb_formatter"
+)]
+class ColorFieldItem extends FieldItemBase {
+
+  /**
+   *
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition): array {
+    $properties['red'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Red value'));
+    $properties['green'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Green value'));
+    $properties['blue'] = DataDefinition::create('integer')->setLabel(new TranslatableMarkup('Blue value'));
+    return $properties;
+  }
+
+  /**
+   *
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition): array {
+    return [
+      'columns' => [
+        'red' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'green' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+        'blue' => ['type' => 'int', 'size' => 'tiny', 'unsigned' => TRUE],
+      ],
+    ];
+  }
+
+  /**
+   *
+   */
+  public function isEmpty(): bool {
+    return $this->get('red')->getValue() === NULL &&
+           $this->get('green')->getValue() === NULL &&
+           $this->get('blue')->getValue() === NULL;
+  }
+
+}

--- a/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
+++ b/omkar_fieldapi/src/Plugin/Field/FieldWidget/ColorFieldWidget.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\omkar_fieldapi\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Attribute\FieldWidget;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[FieldWidget(
+  id: "color_rgb_widget",
+  label: new TranslatableMarkup("Color RGB Widget"),
+  field_types: ["color_rgb"]
+)]
+class ColorFieldWidget extends WidgetBase {
+
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
+    $element['red'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Red'),
+      '#default_value' => $items[$delta]->red ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['green'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Green'),
+      '#default_value' => $items[$delta]->green ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    $element['blue'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Blue'),
+      '#default_value' => $items[$delta]->blue ?? 0,
+      '#min' => 0,
+      '#max' => 255,
+    ];
+    return $element;
+  }
+
+}


### PR DESCRIPTION
This pull request introduces a new custom module, omkar_fieldapi, which provides a custom field type for storing RGB color values using Drupal's Field API. The module includes a field type, widget, and formatter to allow users to input and display color values as RGB components.

Key Features:
-Field Type (color_rgb):
-Stores RGB values as separate red, green, and blue integers.
-Includes database schema definition for efficient storage.
-Implements isEmpty() to handle validation.
-Field Widget (color_rgb_widget):
-Provides numeric input fields for red, green, and blue components.
-Input range restricted from 0 to 255 for each color channel.
-Field Formatter (color_rgb_formatter):
-Outputs color value as a hexadecimal string (e.g., #ff9900).
-Uses #markup render array for simple display.
-Module Info File (omkar_fieldapi.info.yml):
-Registers the module with necessary metadata and dependencies.
-Requires Drupal core version ^11.

Testing Notes:
-Enable the omkar_fieldapi module.
-Add a new field of type "Color RGB" to any content type.
-Test the widget for proper input validation.
![Screenshot from 2025-04-10 08-37-43](https://github.com/user-attachments/assets/44d0e644-5331-4288-ab27-52d88b6eafcc)
