### PR TITLE
feat:(omkar_cache_api):explored cache api to fetch latest added blogs

### DIFF
--- a/omkar_cache_api/omkar_cache_api.info.yml
+++ b/omkar_cache_api/omkar_cache_api.info.yml
@@ -1,0 +1,7 @@
+name: 'Omkar Cache API'
+type: module
+description: 'Caches the latest blog posts to improve performance.'
+core_version_requirement: ^11
+package: Custom
+dependencies:
+  - drupal:node

--- a/omkar_cache_api/omkar_cache_api.module
+++ b/omkar_cache_api/omkar_cache_api.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Omkar Cache API module.
+ */

--- a/omkar_cache_api/omkar_cache_api.routing.yml
+++ b/omkar_cache_api/omkar_cache_api.routing.yml
@@ -1,0 +1,7 @@
+omkar_cache_api.latest_blogs:
+  path: '/latest-blogs'
+  defaults:
+    _controller: '\Drupal\omkar_cache_api\Controller\BlogController::latestBlogs'
+    _title: 'Latest Blog Posts'
+  requirements:
+    _permission: 'access content'

--- a/omkar_cache_api/omkar_cache_api.services.yml
+++ b/omkar_cache_api/omkar_cache_api.services.yml
@@ -1,0 +1,10 @@
+services:
+  omkar_cache_api.blog_cache_service:
+    class: 'Drupal\omkar_cache_api\Service\BlogCacheService'
+    arguments: ['@cache.default']
+
+  omkar_cache_api.blog_event_subscriber:
+    class: 'Drupal\omkar_cache_api\EventSubscriber\BlogEventSubscriber'
+    arguments: ['@omkar_cache_api.blog_cache_service']
+    tags:
+      - { name: event_subscriber }

--- a/omkar_cache_api/src/Controller/BlogController.php
+++ b/omkar_cache_api/src/Controller/BlogController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\omkar_cache_api\Controller;
+
+use Drupal\Core\Url;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\omkar_cache_api\Service\BlogCacheService;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller to display latest cached blog posts.
+ */
+class BlogController extends ControllerBase {
+
+  protected BlogCacheService $blogCacheService;
+  protected LoggerInterface $logger;
+
+  public function __construct(BlogCacheService $blogCacheService, LoggerInterface $logger) {
+    $this->blogCacheService = $blogCacheService;
+    $this->logger = $logger;
+  }
+
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('omkar_cache_api.blog_cache_service'),
+      $container->get('logger.channel.omkar_cache_api')
+    );
+  }
+
+  /**
+   * Returns the latest blog posts.
+   */
+  public function latestBlogs(): array {
+    $blogs = $this->blogCacheService->getLatestBlogs();
+
+    // Debugging: Check if $blogs contains data.
+    $this->logger->notice('<pre>' . print_r($blogs, TRUE) . '</pre>');
+
+    if (empty($blogs)) {
+      return [
+        '#markup' => '<p>No blogs available.</p>',
+      ];
+    }
+
+    $items = [];
+    foreach ($blogs as $blog) {
+      $items[] = [
+        '#type' => 'link',
+        '#title' => $blog['title'],
+        '#url' => Url::fromUserInput($blog['url']),
+      ];
+    }
+
+    return [
+      '#theme' => 'item_list',
+      '#items' => $items,
+      '#cache' => [
+        'tags' => ['node_list'],
+      ],
+    ];
+  }
+
+}

--- a/omkar_cache_api/src/EventSubscriber/BlogEventSubscriber.php
+++ b/omkar_cache_api/src/EventSubscriber/BlogEventSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\omkar_cache_api\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\node\Event\NodeEvent;
+use Drupal\omkar_cache_api\Service\BlogCacheService;
+
+/**
+ * Event Subscriber to clear cache when a blog post is created or updated.
+ */
+class BlogEventSubscriber implements EventSubscriberInterface {
+
+  protected $blogCacheService;
+
+  public function __construct(BlogCacheService $blogCacheService) {
+    $this->blogCacheService = $blogCacheService;
+  }
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'entity.node.insert' => 'clearBlogCache',
+      'entity.node.update' => 'clearBlogCache',
+      'entity.node.delete' => 'clearBlogCache',
+    ];
+  }
+  
+
+  /**
+   * Clears the cache when a blog post is added or updated.
+   */
+  public function clearBlogCache($event) {
+    $node = $event->getNode();
+    if ($node->bundle() == 'blog') {
+      $this->blogCacheService->clearCache();
+    }
+  }
+
+}

--- a/omkar_cache_api/src/Service/BlogCacheService.php
+++ b/omkar_cache_api/src/Service/BlogCacheService.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\omkar_cache_api\Service;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service to cache and retrieve latest blog posts.
+ */
+class BlogCacheService {
+
+  protected CacheBackendInterface $cacheBackend;
+  protected EntityTypeManagerInterface $entityTypeManager;
+  protected LoggerInterface $logger;
+
+  /**
+   * Constructor to inject dependencies.
+   */
+  public function __construct(
+    CacheBackendInterface $cache_backend,
+    EntityTypeManagerInterface $entity_type_manager,
+    LoggerInterface $logger
+  ) {
+    $this->cacheBackend = $cache_backend;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Fetch latest blog posts from cache or database.
+   */
+  public function getLatestBlogs($limit = 5): array {
+    $cid = 'omkar_cache_api:latest_blogs';
+    $cache = $this->cacheBackend->get($cid);
+
+    if ($cache) {
+      $this->logger->notice('Cache HIT: Returning cached data.');
+      return $cache->data;
+    }
+    else {
+      $this->logger->notice('Cache MISS: Fetching from database.');
+
+      $query = $this->entityTypeManager->getStorage('node')->getQuery()
+        ->condition('status', 1)
+        ->condition('type', 'blog')
+        ->sort('created', 'DESC')
+        ->range(0, $limit)
+        ->accessCheck(TRUE);
+
+      $nids = $query->execute();
+      $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+
+      $blogs = [];
+      foreach ($nodes as $node) {
+        $blogs[] = [
+          'title' => $node->getTitle(),
+          'url' => $node->toUrl()->toString(),
+        ];
+      }
+
+      $this->cacheBackend->set($cid, $blogs, CacheBackendInterface::CACHE_PERMANENT, ['node_list']);
+
+      return $blogs;
+    }
+  }
+
+  /**
+   * Clears the cache when a blog post is updated.
+   */
+  public function clearCache(): void {
+    $this->cacheBackend->invalidate('omkar_cache_api:latest_blogs');
+  }
+
+}


### PR DESCRIPTION
This PR introduces a new custom Drupal module, omkar_cache_api, which caches the latest published blog posts to enhance performance and reduce database load. The module provides a service for fetching blog posts with caching support, an event subscriber to invalidate the cache when blog posts are updated, and a controller to display the cached data on a custom route.

📦 Features Included
Custom Service:
BlogCacheService fetches and caches the latest published blog posts using cache.default.

Controller:
BlogController exposes the /latest-blogs route to display cached blog post titles as links.

Event Subscriber:
BlogEventSubscriber listens to node.insert, node.update, and node.delete events for the blog content type and clears the cache accordingly.

Dependency Injection:
All services (logger, entity type manager, cache) are injected properly using constructor injection to follow Drupal best practices.

Custom Route:
/latest-blogs displays the latest blog posts using a themed item list.

🧩 Files Added
omkar_cache_api.services.yml – Registers services and dependencies.

BlogCacheService.php – Core logic for caching.

BlogController.php – Handles route and display logic.

BlogEventSubscriber.php – Automatically clears cache on blog entity changes.

omkar_cache_api.routing.yml – Adds custom route for latest blogs.

omkar_cache_api.info.yml – Module metadata.

omkar_cache_api.module – Empty stub file, currently unused.

🧪 How to Test
Enable the module:
drush en omkar_cache_api

Visit /latest-blogs — should show latest blog posts (or a "No blogs available" message).

Create, update, or delete a blog post — the list should refresh due to cache invalidation.

📌 Notes
Uses @logger.channel.omkar_cache_api for scoped logging.

Cache uses tag node_list for proper invalidation.

Designed for Drupal 11 (core_version_requirement: ^11).